### PR TITLE
patch-5

### DIFF
--- a/src/multilspy/language_servers/typescript_language_server/typescript_language_server.py
+++ b/src/multilspy/language_servers/typescript_language_server/typescript_language_server.py
@@ -19,7 +19,7 @@ from multilspy.lsp_protocol_handler.lsp_types import InitializeParams
 from multilspy.multilspy_config import MultilspyConfig
 from multilspy.multilspy_utils import PlatformUtils, PlatformId
 import traceback
-
+import stat
 
 # Conditionally import pwd module (Unix-only)
 if not PlatformUtils.get_platform_id().value.startswith("win"):
@@ -129,13 +129,26 @@ class TypeScriptLanguageServer(LanguageServer):
                     print(f"[INFO] Running install command: {cmd} in {tsserver_ls_dir}")
                     try:
                         platform_id = PlatformUtils.get_platform_id()
+                        print(f"[DEBUG] Platform ID: {platform_id}")
                         if platform_id.startswith("win"):
+                            print("[DEBUG] Detected Windows platform")
                             subprocess.run(cmd, shell=True, check=True, cwd=tsserver_ls_dir,
-                                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                         else:
                             user = pwd.getpwuid(os.getuid()).pw_name
+                            print(f"[DEBUG] Running as user: {user} (UID={os.getuid()}, GID={os.getgid()})")
+                            # print out directory permissions and ownership for debugging
+                            stat_info = os.stat(tsserver_ls_dir)
+                            print(f"[DEBUG] {tsserver_ls_dir} perms={oct(stat_info.st_mode)} owner={stat_info.st_uid}:{stat_info.st_gid}")
+                            # print out directory permissions and ownership for debugging
+                            stat_info = os.stat(tsserver_ls_dir)
+                            mode_octal = oct(stat.S_IMODE(stat_info.st_mode))
+                            mode_str  = stat.filemode(stat_info.st_mode)
+                            print(f"[DEBUG] {tsserver_ls_dir} owner={stat_info.st_uid}:{stat_info.st_gid}")
+                            print(f"[DEBUG] {tsserver_ls_dir} perms (octal)={mode_octal}")
+                            print(f"[DEBUG] {tsserver_ls_dir} perms (string)={mode_str}")
                             subprocess.run(cmd, shell=True, check=True, cwd=tsserver_ls_dir,
-                                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                         print(f"[INFO] Successfully installed dependency with command: {cmd}")
                     except subprocess.CalledProcessError as cmd_e:
                         print(f"[ERROR] Command failed: {cmd} with error: {cmd_e}\n{traceback.format_exc()}")

--- a/src/multilspy/language_servers/typescript_language_server/typescript_language_server.py
+++ b/src/multilspy/language_servers/typescript_language_server/typescript_language_server.py
@@ -134,7 +134,7 @@ class TypeScriptLanguageServer(LanguageServer):
                                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                         else:
                             user = pwd.getpwuid(os.getuid()).pw_name
-                            subprocess.run(cmd, shell=True, check=True, cwd=tsserver_ls_dir, user=user,
+                            subprocess.run(cmd, shell=True, check=True, cwd=tsserver_ls_dir,
                                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                         print(f"[INFO] Successfully installed dependency with command: {cmd}")
                     except subprocess.CalledProcessError as cmd_e:


### PR DESCRIPTION
## **CodeAnt-AI Description**
- Removed the `user` parameter from the `subprocess.run` call in the TypeScript language server setup for non-Windows systems, preventing potential runtime errors due to unsupported argument usage.

This PR fixes a bug where the subprocess for installing dependencies could fail on non-Windows systems because the `user` parameter is not supported by `subprocess.run`. The change ensures smoother dependency installation and improves cross-platform compatibility.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>typescript_language_server.py</strong><dd><code>Fix subprocess.run usage by removing unsupported user argument on <br>non-Windows</code></dd></summary>
<hr>

src/multilspy/language_servers/typescript_language_server/typescript_language_server.py
<li>Removed the <code>user</code> argument from the <code>subprocess.run</code> call on non-Windows <br>systems.<br> <li> Ensured consistent behavior for dependency installation subprocess <br>invocation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/CodeAnt-AI/multilspy/pull/6/files#diff-d4a85c0bce927d0c45429f684a4ab5348150354d12ceb2ff91dfeefdf085027e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://codehealth.commvault.com](https://codehealth.commvault.com). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
